### PR TITLE
docs(readme): list cascading files with 1p docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
 # qte77/.github
 
 Default community health files for repositories owned by
-[@qte77](https://github.com/qte77).
+[@qte77](https://github.com/qte77). Files here are inherited by any
+`qte77/*` repository that does not define its own.
 
-Files here are inherited by every `qte77/*` repository that does not define
-its own equivalent. See GitHub's
-[default community health file docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)
-for how the cascade works.
+## Active (cascading)
 
-Nothing here is project-specific — see individual repositories for their
-own docs.
+| File | Purpose |
+|---|---|
+| `CODE_OF_CONDUCT.md` | Conduct rules across all qte77 projects |
+| `CONTRIBUTING.md` | How to contribute |
+| `SECURITY.md` | Vulnerability reporting |
+| `SUPPORT.md` | Where to ask questions |
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | Bug report form |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | Feature request form |
+| `.github/ISSUE_TEMPLATE/config.yml` | Issue chooser config |
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR description template |
+
+## Drafts (not yet cascading)
+
+| File | Will cascade as |
+|---|---|
+| `.github/drafts/GOVERNANCE.md` | `GOVERNANCE.md` (root) |
+| `.github/drafts/DISCUSSION_TEMPLATE/*.yml` | `.github/DISCUSSION_TEMPLATE/*.yml` |
+
+## Not cascadable (must live per-repo)
+
+- `LICENSE` / `NOTICE` — copy into each repo individually
+- `README.md` — repo-specific
+
+## References
+
+- Default community health files: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file
+- Licensing a repository: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository
+- User profile README: https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme


### PR DESCRIPTION
## Summary
- Replace generic README with a file-inventory table separating active (cascading) from drafts and per-repo files
- Add canonical GitHub docs links so contributors can verify cascade behavior

## Why
Reviewers and contributors need to know which files cascade and which don't (LICENSE, README) without reading the source code of every repo.

Generated with Claude <noreply@anthropic.com>