### PR TITLE
ci(lint): add markdown + link-check workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: "**/*.md"
+          config: ".markdownlint.jsonc"
+
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress '**/*.md'
+          fail: true
+...


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/lint.yml` runs markdownlint-cli2 and lychee on push/PR to main
- Uses configs added in #7

## Why
Catches markdown drift and broken links in this meta-repo before merge.

Generated with Claude <noreply@anthropic.com>