### PR TITLE
chore(ci): rename workflow to 'Lint MD and Links'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 ---
-name: Lint
+name: Lint MD and Links
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Workflow `name:` changed from `Lint` to `Lint MD and Links` for clearer labeling in the Actions UI and on PR check lists

Generated with Claude <noreply@anthropic.com>