### PR TITLE
feat(ci): add notify_on_failure input for scheduled monitoring

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -8,6 +8,11 @@ on:
     branches: [main]
   workflow_dispatch:
   workflow_call:
+    inputs:
+      notify_on_failure:
+        description: "Create an issue if a lint job fails (use with cron callers)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -37,4 +42,23 @@ jobs:
         with:
           args: --no-progress '**/*.md'
           fail: true
+
+  notify:
+    needs: [markdown, links]
+    if: failure() && inputs.notify_on_failure
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Lint MD and Links: failure on ${context.ref}`,
+              body: `One or more lint jobs failed.\n\nRun: ${runUrl}`,
+              labels: ['report', 'automated']
+            });
 ...

--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ For stricter reproducibility, callers can pin the `uses:` ref to a SHA instead o
 uses: qte77/.github/.github/workflows/lint-md-links.yml@<SHA>  # bump on .github updates
 ```
 
+### Scheduled monitoring (opt-in)
+
+The reusable workflow accepts a `notify_on_failure` input. Set it to `true` from a caller with a `cron` trigger to get an automated issue when scheduled lint runs fail (catches link rot on idle repos):
+
+```yaml
+name: Lint Monitor
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # weekly Sunday midnight UTC
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  monitor:
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@main
+    with:
+      notify_on_failure: true
+    permissions:
+      contents: read
+      issues: write
+```
+
+PR-blocking callers leave `notify_on_failure` unset (default `false`); no `issues: write` permission needed.
+
 ## Lint configs
 
 These templates pair with the reusable lint workflow above. Copy into a downstream repo to override the fallback fetched from `main`.


### PR DESCRIPTION
## Summary
- Add optional `notify_on_failure` input to the reusable lint workflow. When `true`, a `notify` job creates an issue if any lint job fails.
- Default `false` — existing 30+ PR-blocking callers unchanged
- README documents the cron-monitor caller pattern

## Why
After removing the old per-repo `links-fail-fast.yaml` (cron + issue creation), some long-lived repos still want background link rot monitoring. Single workflow, opt-in input — KISS+DRY: one lint implementation, two trigger patterns.

Generated with Claude <noreply@anthropic.com>