### PR TITLE
ci(lint): skip markdown job on scheduled runs

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -21,6 +21,9 @@ permissions:
 
 jobs:
   markdown:
+    # Skip markdown lint on scheduled runs — md content is stable post-merge;
+    # only links rot independently. Schedule runs only check links.
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ jobs:
 
 One caller file, one job — never two files. The `schedule:` trigger must live in the caller because reusable workflows cannot propagate `schedule:` to callers (see [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_call)).
 
+**Schedule runs only check links** — the markdown job is skipped on `schedule` events because markdown content is stable post-merge; only links rot independently. PR/push runs check both.
+
 Repos that don't need cron monitoring can omit the `schedule:` trigger and the `issues: write` permission.
 
 ### Keeping caller SHA pins fresh


### PR DESCRIPTION
## Summary
- Add `if: github.event_name != 'schedule'` to the markdown job in the SoT reusable workflow
- README updated to document the behavior

## Why
Scheduled runs target link rot detection. Markdown rules are stable rule-checks against unchanged content — re-running them on cron wastes CI time. Schedule events now only execute the link job; PR/push events still run both.

## Mechanism
`github.event_name` in a `workflow_call` workflow reflects the caller's triggering event. No new input — inspect the event directly.

Generated with Claude <noreply@anthropic.com>