### PR TITLE
docs(lint): recommend markdownlint-cli2 for local linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ These templates pair with the reusable lint workflow above. Copy into a downstre
 | `.markdownlint.jsonc` | Markdown style rules (MD013 disabled, MD060 padded tables, frontmatter-aware MD041) |
 | `lychee.toml` | Link checker config (accept common bot-blocking codes) |
 
+### Local linting
+
+Install `markdownlint-cli2` to match CI behavior (the action uses cli2). The older `markdownlint` CLI does not honor `.markdownlint-cli2.jsonc` ignore files, which causes local-vs-CI discrepancies.
+
+```bash
+npm install -g markdownlint-cli2
+markdownlint-cli2 '**/*.md'
+```
+
 ## References
 
 - Default community health files: <https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file>


### PR DESCRIPTION
## Summary
Document `markdownlint-cli2` as the canonical local linter to match CI.

## Why
The CI action (`DavidAnson/markdownlint-cli2-action`) is cli2; running cli1 (`markdownlint`) locally produces false positives because cli1 does not honor `.markdownlint-cli2.jsonc` ignore files. Aligning local on cli2 eliminates the discrepancy.

Generated with Claude <noreply@anthropic.com>