### PR TITLE
feat(ci): add reusable bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,159 @@
+---
+name: Bump Version
+
+on:
+  workflow_call:
+    inputs:
+      bump_type:
+        description: "Version bump type: patch, minor, or major"
+        required: true
+        type: string
+      python_version:
+        description: "Python version for actions/setup-python"
+        required: false
+        type: string
+        default: "3.13"
+      bump_my_version_pin:
+        description: "Pip version spec for bump-my-version"
+        required: false
+        type: string
+        default: "1.3.0"
+      branch_prefix:
+        description: "Prefix for the bump branch name"
+        required: false
+        type: string
+        default: "bump"
+      pr_title_template:
+        description: "PR title template ({previous} and {current} are substituted)"
+        required: false
+        type: string
+        default: "chore(release): bump {previous} → {current}"
+      open_pr:
+        description: "Open a PR after pushing the bump branch (set to 'false' to skip)"
+        required: false
+        type: string
+        default: "true"
+    outputs:
+      previous_version:
+        description: "Version before bump"
+        value: ${{ jobs.bump.outputs.previous_version }}
+      current_version:
+        description: "Version after bump"
+        value: ${{ jobs.bump.outputs.current_version }}
+      branch:
+        description: "Bump branch name"
+        value: ${{ jobs.bump.outputs.branch }}
+      pr_url:
+        description: "PR URL (empty when open_pr=false)"
+        value: ${{ jobs.bump.outputs.pr_url }}
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      previous_version: ${{ steps.bump.outputs.previous_version }}
+      current_version: ${{ steps.bump.outputs.current_version }}
+      branch: ${{ steps.commit.outputs.branch }}
+      pr_url: ${{ steps.pr.outputs.pr_url }}
+    env:
+      REPO: ${{ github.repository }}
+      BASE_REF: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install bump-my-version
+        env:
+          PIN: ${{ inputs.bump_my_version_pin }}
+        run: pip install "bump-my-version==$PIN"
+
+      - name: Bump version (files only)
+        id: bump
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: |
+          previous=$(bump-my-version show current_version)
+          bump-my-version bump "$BUMP_TYPE"
+          current=$(bump-my-version show current_version)
+          echo "previous_version=$previous" >> "$GITHUB_OUTPUT"
+          echo "current_version=$current" >> "$GITHUB_OUTPUT"
+
+      - name: Signed commit and push branch
+        id: commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREV: ${{ steps.bump.outputs.previous_version }}
+          CURR: ${{ steps.bump.outputs.current_version }}
+          BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          BRANCH="$BRANCH_PREFIX-$RUN_NUMBER-$BASE_REF"
+
+          BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/$BASE_REF" --jq '.object.sha')
+          BASE_TREE=$(gh api "repos/$REPO/git/commits/$BASE_SHA" --jq '.tree.sha')
+
+          TREE_ENTRIES="[]"
+          for file in $(git diff --name-only); do
+            CONTENT=$(base64 -w0 "$file")
+            BLOB_SHA=$(gh api "repos/$REPO/git/blobs" -f content="$CONTENT" -f encoding=base64 --jq '.sha')
+            TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq --arg path "$file" --arg sha "$BLOB_SHA" \
+              '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+          done
+
+          NEW_TREE=$(gh api "repos/$REPO/git/trees" \
+            --input <(jq -n --arg base "$BASE_TREE" --argjson tree "$TREE_ENTRIES" \
+              '{base_tree: $base, tree: $tree}') \
+            --jq '.sha')
+
+          COMMIT_SHA=$(gh api "repos/$REPO/git/commits" \
+            --input <(jq -n --arg msg "Bump version: $PREV -> $CURR" \
+              --arg tree "$NEW_TREE" --arg parent "$BASE_SHA" \
+              '{message: $msg, tree: $tree, parents: [$parent]}') \
+            --jq '.sha')
+
+          gh api "repos/$REPO/git/refs/heads/$BRANCH" -X PATCH -f sha="$COMMIT_SHA" -F force=true 2>/dev/null \
+            || gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$COMMIT_SHA"
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR
+        id: pr
+        if: inputs.open_pr == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREV: ${{ steps.bump.outputs.previous_version }}
+          CURR: ${{ steps.bump.outputs.current_version }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          TEMPLATE: ${{ inputs.pr_title_template }}
+        run: |
+          title="${TEMPLATE//\{previous\}/$PREV}"
+          title="${title//\{current\}/$CURR}"
+          body="Automated version bump from \`$PREV\` to \`$CURR\` on \`$BRANCH\`."
+          pr_url=$(gh pr create \
+            --base "$BASE_REF" \
+            --head "$BRANCH" \
+            --title "$title" \
+            --body "$body")
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Cleanup on failure
+        # Cleanup intentionally omits tag/release deletion: GitHub's release
+        # immutability remembers deleted tag names forever, so deleting on
+        # failure permanently burns the version number. See qte77/.github#23.
+        if: failure() || cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          BRANCH="$BRANCH_PREFIX-$RUN_NUMBER-$BASE_REF"
+          gh pr close "$BRANCH" --comment "Closing PR '$BRANCH' to rollback after failure" 2>/dev/null || true
+          gh api "repos/$REPO/git/refs/heads/$BRANCH" -X DELETE 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Workflows downstream `qte77/*` repos can call directly. Configs (`.markdownlint.
 | Workflow | Purpose |
 |---|---|
 | `.github/workflows/lint-md-links.yml` | Markdown + link checking (markdownlint-cli2 + lychee) |
+| `.github/workflows/bump-version.yml` | Version bump → signed commit → PR (via `bump-my-version`) |
 
 Caller usage:
 
@@ -87,6 +88,51 @@ One caller file, one job — never two files. The `schedule:` trigger must live 
 **Schedule runs only check links** — the markdown job is skipped on `schedule` events because markdown content is stable post-merge; only links rot independently. PR/push runs check both.
 
 Repos that don't need cron monitoring can omit the `schedule:` trigger and the `issues: write` permission.
+
+### Bump version (workflow_dispatch)
+
+The `bump-version.yml` reusable workflow runs `bump-my-version` on the caller's project, makes a signed commit via the GitHub API, pushes a bump branch, and opens a PR. It does **not** create tags or releases — that stays a separate concern. After the bump PR merges, run `gh release create vX.Y.Z` manually; release automation is a [follow-up](https://github.com/qte77/.github/issues/23).
+
+```yaml
+name: Bump Version
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "[major|minor|patch]"
+        required: true
+        type: choice
+        options: [patch, minor, major]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  bump:
+    uses: qte77/.github/.github/workflows/bump-version.yml@<SHA>
+    with:
+      bump_type: ${{ inputs.bump_type }}
+    secrets: inherit
+```
+
+Consumer-repo prerequisites:
+
+- *Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"* must be enabled, otherwise `gh pr create` returns `403 not authorized`.
+- A bumpversion source must be present in the caller repo. Typical setup is `pyproject.toml` with a `[tool.bumpversion]` table containing `current_version` and any `[[tool.bumpversion.files]]` entries.
+
+Inputs (all optional except `bump_type`):
+
+| Input | Default | Notes |
+|---|---|---|
+| `bump_type` | — | `patch` / `minor` / `major` |
+| `python_version` | `"3.13"` | Passed to `actions/setup-python` |
+| `bump_my_version_pin` | `"1.3.0"` | Pip version spec |
+| `branch_prefix` | `"bump"` | Branch is `<prefix>-<run_number>-<ref_name>` |
+| `pr_title_template` | `"chore(release): bump {previous} → {current}"` | `{previous}` / `{current}` substituted at runtime |
+| `open_pr` | `"true"` | Set to `"false"` to push the branch but skip PR creation |
+
+Outputs: `previous_version`, `current_version`, `branch`, `pr_url`.
+
+On failure or cancellation, the workflow closes the PR (if any) and deletes the bump branch. It **never** deletes tags or releases — GitHub's release-immutability setting remembers deleted tag names forever, so deleting on failure permanently burns the version number (see [#23](https://github.com/qte77/.github/issues/23) for the incident that led to this rule).
 
 ### Keeping caller SHA pins fresh
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/bump-version.yml` — `workflow_call` reusable workflow that pip-installs `bump-my-version`, makes a signed commit via the GitHub API, pushes a bump branch, and optionally opens a PR. **No tag, no release, no floating-tag update.**
- Failure cleanup closes PR + deletes branch only — **never** deletes tags/releases (GitHub's release-immutability remembers deleted tag names forever; deleting on failure permanently burns the version number).
- Document caller usage in `README.md` including the consumer-repo prerequisite ("Allow GitHub Actions to create and approve pull requests") and the bumpversion-source requirement.

## Background

Eight `qte77/gha-*` repos ship a byte-for-byte identical `bump-and-release.yaml` with a cleanup script that deletes tags on failure. Combined with release immutability (default-enabled), every failed dispatch burns the version. `gha-contribution-ascii` `v2.3.0` is permanently unreachable; `v2.3.1` shipped manually. Local fix landed in [gha-contribution-ascii#89](https://github.com/qte77/gha-contribution-ascii/pull/89). This PR centralises the fixed bump flow so consumers can replace ~80 lines of per-repo `bump-and-release.yaml` with a ~15-line caller. Tracking issue: #23.

## Scope

- Phase 1 only: author the central reusable workflow + docs in this repo.
- Out of scope (separate follow-ups): consumer migrations (Phase 2 canary on `gha-issue-triage` or `gha-llms-txt-action`, Phase 3 rollout), and a `release.yml` companion workflow.

## Test plan

- [x] Local: `markdownlint-cli2 README.md` — clean.
- [x] Local: `actionlint .github/workflows/bump-version.yml` — clean.
- [ ] CI: `lint-md-links` workflow on this PR (markdown + lychee) — green.
- [ ] CI: GitHub workflow-syntax validation surfaces no errors on the Actions tab.
- [ ] Post-merge canary (Phase 2, separate work): point a low-risk consumer at `qte77/.github/.github/workflows/bump-version.yml@<merge-SHA>`, dispatch a `patch` bump, verify branch+PR created, no tag created, no release created. Cross-check `gh api repos/<owner>/<repo>/releases --jq '.[].tag_name'` before dispatch to confirm the version is unburned.
- [ ] Post-merge canary: deliberately fail a step mid-run, verify cleanup closes PR + deletes branch but leaves no tag/release artefacts.
- [ ] Post-merge canary: dispatch with `open_pr: "false"`, verify branch is pushed but no PR is opened.

Generated with Claude <noreply@anthropic.com>