### PR TITLE
docs(lint): clarify issues:write is required even without notify

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -1,4 +1,19 @@
 ---
+# Reusable workflow: Markdown + link linting (markdownlint-cli2 + lychee).
+#
+# CALLER PERMISSIONS REQUIRED:
+#   permissions:
+#     contents: read
+#     issues:   write   # required at workflow startup; see note below
+#
+# The `notify` job declares `permissions: issues: write` unconditionally.
+# GitHub validates ALL reusable-job permissions at workflow startup, BEFORE
+# evaluating `if:` expressions — so callers must grant `issues: write` even
+# when `notify_on_failure: false` (the default). Omitting it yields
+# `startup_failure` on every run, despite the notify job being skipped at
+# runtime.
+#
+# See README "Permissions required" for the bare-minimum caller shape.
 name: Lint MD and Links
 
 on:
@@ -12,7 +27,7 @@ on:
   workflow_call:
     inputs:
       notify_on_failure:
-        description: "Create an issue if a lint job fails (use with cron callers)"
+        description: "Create a GitHub issue on lint failure (use with cron callers). Default false. Callers must always grant `issues: write` regardless — see workflow header comment."
         type: boolean
         default: false
 
@@ -50,6 +65,9 @@ jobs:
 
   notify:
     needs: [markdown, links]
+    # Skipped at runtime when notify_on_failure is false (the default), but
+    # the `permissions: issues: write` declaration below is still validated
+    # at startup — callers must grant it regardless. See workflow header.
     if: failure() && inputs.notify_on_failure
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,25 @@ One caller file, one job — never two files. The `schedule:` trigger must live 
 
 **Schedule runs only check links** — the markdown job is skipped on `schedule` events because markdown content is stable post-merge; only links rot independently. PR/push runs check both.
 
-Repos that don't need cron monitoring can omit the `schedule:` trigger and the `issues: write` permission.
+Repos that don't need cron monitoring can omit the `schedule:` trigger and drop the `with: notify_on_failure:` line. **The `issues: write` permission must still be granted**, however — the reusable's `notify` job declares it unconditionally, and GitHub Actions validates all reusable-job permissions at workflow startup, *before* `if:` conditions are evaluated. Omitting it yields `startup_failure` on every run, even when `notify_on_failure` is `false` and the notify job is correctly skipped at runtime.
+
+Minimal caller (no cron, no notify):
+
+```yaml
+name: Lint MD and Links
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write  # required at workflow startup even when not opting into notify
+jobs:
+  lint:
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@<SHA>
+```
 
 ### Bump version (workflow_dispatch)
 


### PR DESCRIPTION
## Why

`qte77/gha-issue-triage` followed the README's note at line 90 ("Repos that don't need cron monitoring can omit the `schedule:` trigger and the `issues: write` permission") and consequently hit `startup_failure` on **every** lint-md-links run for 66+ consecutive runs (2026-04-27 → 2026-05-15). Just fixed it there in [qte77/gha-issue-triage#55](https://github.com/qte77/gha-issue-triage/pull/55).

Root cause: the reusable's `notify` job declares `permissions: issues: write` unconditionally. GitHub validates **all** reusable-job permissions at workflow startup, **before** evaluating `if:` expressions. So even when a caller passes `notify_on_failure: false` (the default) and notify is correctly skipped at runtime, the caller still must grant `issues: write` or the workflow refuses to start.

The README's current claim is the opposite — and led to the incident.

## What

**README.md** (line 90): rewrite the misleading paragraph and add a minimal-caller code block for the no-cron / no-notify case. The new copy explicitly states `issues: write` is required regardless and explains *why* (startup-time validation, not runtime evaluation).

**`.github/workflows/lint-md-links.yml`**:

- Add a workflow header comment block describing the caller permission requirement and the startup-vs-runtime validation distinction
- Tighten the `notify_on_failure` input description to call out the default and the permission cost
- Add an inline comment on the `notify` job's `if:` line cross-referencing the header

## Out of scope

The structural fix (splitting the reusable so non-notify callers genuinely don't need `issues: write`) is a real option but adds a second reusable file to maintain. Per discussion in [qte77/gha-issue-triage](https://github.com/qte77/gha-issue-triage) today, we're keeping the single-file architecture and absorbing the cost via documentation. If the cost becomes painful for many consumers, revisit then.

## Test plan

- [x] Diff confirms only the two intended files change; no behavioural diff in the reusable (header is comments-only)
- [ ] After merge, downstream callers updated to grant `issues: write` will continue to work (this PR doesn't break existing monitor-style callers; `qte77/.github`'s own use of the reusable already grants the permission)
- [ ] README renders cleanly on GitHub (no markdownlint failures from the new code block)