### PR TITLE
docs: document template/CLI cascade gap (README as source of truth)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,13 @@ Thanks for considering a contribution.
 - Reference related issues (`Closes #123`)
 - Ensure CI passes before requesting review
 
+> **Templates & the CLI:** PR, issue, and discussion templates auto-populate
+> only in the web UI — `gh`/the REST API won't pull these owner-level defaults.
+> A repo's own committed template always takes precedence; only when none exists
+> does the cascade apply, sourced from the git-tracked file in `qte77/.github`.
+> When scripting, use the web UI or fetch that file explicitly. See the
+> [cascade notes](https://github.com/qte77/.github/blob/main/README.md#cascading-files).
+
 ## Commit messages
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The cascade applies to GitHub-rendered surfaces only (Security tab, issue choose
 - `https://github.com/qte77/<repo>/security/policy` (renders cascaded content)
 - `https://github.com/qte77/.github/blob/main/<file>` (canonical source)
 
+Cascaded **PR, issue, and discussion templates** auto-populate **only in the web UI**. `gh` and the REST API read templates from the local repo and won't pull these owner-level defaults, so scripted PR/issue creation must use the web UI or fetch the template explicitly.
+
 ## Templates (not cascadable)
 
 These must live in each repo individually — copy from here when bootstrapping a new repo.


### PR DESCRIPTION
## Summary

Documents that cascaded **PR, issue, and discussion templates auto-populate only
in the GitHub web UI** — `gh` and the REST API read templates from the local
repo and won't pull these owner-level defaults.

Keeps the README as the single source of truth for cascade behavior; CONTRIBUTING
carries only a brief actionable pointer that links back to it (no duplication).

- `README.md`: add the CLI caveat to the existing "Cascading files" section
- `CONTRIBUTING.md`: trim the note to a one-liner + link to the README

## Related issues

Context: qte77/claude-code-plugins#161 (proposes the `commit-helper` skill fetch
the owner-level template as a fallback).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Checklist

- [ ] Tests added or updated — N/A (docs only)
- [x] Docs updated where applicable
- [x] CI passes locally — docs-only
- [x] Self-reviewed the diff